### PR TITLE
enable ansi terminal coloring

### DIFF
--- a/configs/winLinkBinaryConfig.json
+++ b/configs/winLinkBinaryConfig.json
@@ -1,0 +1,8 @@
+{
+    "action": "binary",
+    "configs": [
+      {
+        "binaryPath": "build\\int-tests\\windows\\link\\nasm\\Release\\main.exe"
+      }
+    ]
+}

--- a/configs/winLinkdiffConfig.json
+++ b/configs/winLinkdiffConfig.json
@@ -1,0 +1,11 @@
+{
+  "action": "diff",
+  "configs": [
+    {
+      "binaryPath":  "build\\int-tests\\windows\\link\\nasm\\Release\\main.exe"
+    },
+    {
+      "binaryPath":  "build\\int-tests\\windows\\link\\masm64\\Debug\\hello.exe"
+    }
+  ]
+}

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -3,8 +3,10 @@
 // license that can be found in the LICENSE file.
 
 #include "autocli.h"
+#include "runtime/ansiConsole.h"
 
 int main(int argc, char **argv) {
+  ansiColors::enableAnsiColors();
   AutoCLI parser(argc, argv);
   return 0;
 }

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -10,7 +10,14 @@ set(HeaderFiles
     rawDisassemble.h
     runtime.h
     internalData.h
+    ansiConsole.h
 )
+
+if(WIN32)
+    list(APPEND SourceFiles
+         ansiWindows.cpp
+    )
+endif()
 
 add_library (Disassembler.Runtime OBJECT
             ${SourceFiles} ${HeaderFiles}

--- a/src/runtime/ansiConsole.h
+++ b/src/runtime/ansiConsole.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2021 Farzon Lotfi All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef __ansi_console_h__
+#define __ansi_console_h__
+
+namespace ansiColors {
+void enableAnsiColors();
+} // namespace ansiColors
+
+#ifndef _WIN32
+void ansiColors::enableAnsiColors() {}
+#endif
+#endif // __ansi_console_h__

--- a/src/runtime/ansiWindows.cpp
+++ b/src/runtime/ansiWindows.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 Farzon Lotfi All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "ansiConsole.h"
+#include <windows.h>
+#ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+#define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+#endif
+
+// Note we should add a logging library and add
+// log warnings at all the return statements.
+// https://github.com/Gozihr/Disassembler/issues/69
+void ansiColors::enableAnsiColors() {
+  HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+  if (hOut == INVALID_HANDLE_VALUE) {
+    return;
+  }
+  DWORD dwMode = 0;
+  if (!GetConsoleMode(hOut, &dwMode)) {
+    return;
+  }
+  dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+  if (!SetConsoleMode(hOut, dwMode)) {
+    return;
+  }
+}


### PR DESCRIPTION
This change adds ansi colors to windows diffs. This comes with a performance hit not seen in git bash.

resolves #68